### PR TITLE
Add BrowserRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ repositories {
 }
 
 dependencies {
-    implementation("app.softwork:routing-compose:0.0.1")
+    implementation("app.softwork:routing-compose:0.0.10")
 }
 ````
 
 ## Usage
+
+Example with `HashRouter`, `BrowserRouter` will be implemented in the same manner.
+
 ```kotlin
 HashRouter(initRoute = "/users") {
     route("/users") {
@@ -39,3 +42,35 @@ HashRouter(initRoute = "/users") {
     }
 }
 ```
+
+RoutingCompose offers two routing implementations, `HashRouter` and `BrowserRouter`.
+
+[This article](https://blog.bitsrc.io/using-hashed-vs-nonhashed-url-paths-in-single-page-apps-a66234cefc96) provides a good explanation of the difference between each routing strategy.
+
+### HashRouter
+`HashRouter` is used for hashed urls (e.g. yoursite.com/#/path). This strategy requires no additional setup to work in a single page compose-web application.
+
+### BrowserRouter
+
+`BrowserRouter` is used for traditional urls (e.g. yoursite.com/path). Using this strategy will require additional work in a single page compose-web application, requiring you to implement a catch-all strategy to return the same html resource for all paths. This strategy will be different for different server configurations.
+
+#### Development usage:
+The `browser` target for Kotlin/JS uses [webpack-dev-server](https://github.com/webpack/webpack-dev-server) as a local development server. We need our webpack config to serve `index.html` (or your primary html file) for all paths to work with `BrowserRouter`. This is done in webpack-dev-server through the webpack config's [devServer.historyApiFallback](https://webpack.js.org/configuration/dev-server/#devserverhistoryapifallback) flag.
+
+The Kotlin webpack DSL currently [does not support the `historyApiFallback` flag](https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig.kt#L165), but we can add it through additional [webpack configuration files](https://kotlinlang.org/docs/js-project-setup.html#webpack-configuration-file) that will be merged with the auto-generated `webpack.config.js` when building.
+
+##### Instructions
+First, create a directory in the top-most project directory named `webpack.config.d`.
+
+Create a new `.js` file containing a `config.devServer` configuration setting `historyApiFallback = true`. You can name this file any name you wish, it will be merged into the project's main `webpack.config.js`.
+
+```javascript
+// YourProject/webpack.config.d/devServerConfig.js
+
+config.devServer = {
+  ...config.devServer, // Merge with other devServer settings
+  "historyApiFallback": true
+};
+```
+
+Then run your web app and it should route all paths to a valid route. You can confirm this by refreshing or manually entering a path.

--- a/src/jsMain/kotlin/app/softwork/routingcompose/BrowserRouter.kt
+++ b/src/jsMain/kotlin/app/softwork/routingcompose/BrowserRouter.kt
@@ -1,0 +1,64 @@
+package app.softwork.routingcompose
+
+
+import androidx.compose.runtime.*
+import kotlinx.browser.*
+
+/**
+ * A router leveraging the History API (https://developer.mozilla.org/en-US/docs/Web/API/History).
+ */
+public object BrowserRouter : Router {
+    private var subCounter = 0
+    private val subscriber: MutableMap<Int, (String) -> Unit> = mutableMapOf()
+
+    private fun subscribe(block: (String) -> Unit): Int {
+        subscriber[subCounter] = block
+        return subCounter.also {
+            subCounter += 1
+        }
+    }
+
+    init {
+        window.onpopstate = {
+            notifySubscribersOfNewPath()
+        }
+    }
+
+    private fun notifySubscribersOfNewPath(newPath: String = window.location.pathname) {
+        subscriber.entries.forEach { (_, fn) ->
+            fn(newPath)
+        }
+    }
+
+    private fun removeSubscription(id: Int) {
+        subscriber.remove(id)
+    }
+
+    override fun navigate(to: String) {
+        require(to.startsWith("/"))
+
+        window.history.pushState(null, "", to)
+        /*
+        The history API unfortunately provides no callback to listen for
+        [window.history.pushState], so we need to notify subscribers when pushing a new path.
+         */
+        notifySubscribersOfNewPath()
+    }
+
+    @Composable
+    override fun getPath(initRoute: String): State<String> {
+        require(initRoute.startsWith("/")) { "initRoute must start with a slash." }
+
+        val defaultPath = window.location.pathname.ifBlank { initRoute }
+        val path = remember { mutableStateOf(defaultPath) }
+        DisposableEffect(Unit) {
+            val id = subscribe {
+                path.value = it
+            }
+            onDispose {
+                removeSubscription(id)
+            }
+        }
+        return path
+    }
+}

--- a/src/jsMain/kotlin/app/softwork/routingcompose/BrowserRouter.kt
+++ b/src/jsMain/kotlin/app/softwork/routingcompose/BrowserRouter.kt
@@ -6,6 +6,15 @@ import kotlinx.browser.*
 
 /**
  * A router leveraging the History API (https://developer.mozilla.org/en-US/docs/Web/API/History).
+ *
+ * Using a BrowserRouter requires you to implement a catch-all to send the same resource for
+ * every path the router intends to control. BrowserRouter will handle the proper child composition.
+ *
+ * Without a catch-all rule, will get a 404 or "Cannot GET /path" error each time you refresh or
+ * request a specific path. Each server's implementation of a catch-all will be different and you
+ * should handle this based on the webserver environment you're running.
+ *
+ * For more information about this catch-all on
  */
 public object BrowserRouter : Router {
     private var subCounter = 0

--- a/src/jsMain/kotlin/app/softwork/routingcompose/BrowserRouter.kt
+++ b/src/jsMain/kotlin/app/softwork/routingcompose/BrowserRouter.kt
@@ -14,7 +14,9 @@ import kotlinx.browser.*
  * request a specific path. Each server's implementation of a catch-all will be different and you
  * should handle this based on the webserver environment you're running.
  *
- * For more information about this catch-all on
+ * For more information about this catch-all, check your webserver implementation's specific
+ * instructions. For development environments, see the RoutingCompose Readme
+ * for full instructions.
  */
 public object BrowserRouter : Router {
     private var subCounter = 0

--- a/src/jsMain/kotlin/app/softwork/routingcompose/NavLink.kt
+++ b/src/jsMain/kotlin/app/softwork/routingcompose/NavLink.kt
@@ -4,16 +4,21 @@ import androidx.compose.runtime.*
 import org.jetbrains.compose.web.attributes.*
 import org.jetbrains.compose.web.dom.*
 
+/**
+ * Routing navigation Composable that will navigate to the provided path leveraging
+ * the top-most Router implementation.
+ */
 @Composable
 public fun NavLink(
     to: String,
     attrs: AttrsBuilder<Tag.A>.() -> Unit = {},
     content: @Composable () -> Unit
 ) {
+    val router = RouterCompositionLocal.current
     A(attrs = {
         attrs()
         onClick {
-            HashRouter.navigate(to)
+            router.navigate(to)
         }
     }) { content() }
 }

--- a/src/jsMain/kotlin/app/softwork/routingcompose/Router.kt
+++ b/src/jsMain/kotlin/app/softwork/routingcompose/Router.kt
@@ -9,8 +9,8 @@ import androidx.compose.runtime.*
  * This is particularly useful for [NavLink], so we can have a single Composable
  * agnostic of the top level router implementation.
  */
-public val RouterCompositionLocal: ProvidableCompositionLocal<Router> =
-    staticCompositionLocalOf { error("Stupid error") }
+internal val RouterCompositionLocal: ProvidableCompositionLocal<Router> =
+    staticCompositionLocalOf { error("Router not defined, cannot provide through RouterCompositionLocal.") }
 
 public interface Router {
 


### PR DESCRIPTION
- Adds `BrowserRouter` for leveraging routing through the History API.
- Updates `NavLink` to route through whichever router is being leveraged using a `CompositionLocal`.

Tested locally with a personal site I'm currently building.

Left to-do (as part of this PR or I can add in a future one):
- Add unit tests and integration test just like those for `HashRouter`.
- Determine best way to route when navigating directly to a path. For SPAs, which I think most implementations of compose-web will be, this is usually handled on the server to return the same resource for any path `/*` in which this should handle this. 

@hfhbd let me know your thoughts!