### PR TITLE
NavLink for JS improvements

### DIFF
--- a/src/jsMain/kotlin/app/softwork/routingcompose/NavLink.kt
+++ b/src/jsMain/kotlin/app/softwork/routingcompose/NavLink.kt
@@ -13,19 +13,23 @@ import org.w3c.dom.*
 @Composable
 public fun NavLink(
     to: String,
-    attrs: (AttrsScope<HTMLAnchorElement>.() -> Unit)? = null,
-    content: @Composable () -> Unit
+    attrs: AttrBuilderContext<HTMLAnchorElement>? = null,
+    content: ContentBuilder<HTMLAnchorElement>? = null
 ) {
     val router = Router.current
     A(
+        href = to,
         attrs = {
-            attrs?.invoke(this)
             if (router.currentPath.path.startsWith(to)) {
                 classes("active")
             }
             onClick {
+                if (it.ctrlKey || it.metaKey) return@onClick
                 router.navigate(to)
+                it.preventDefault()
             }
-        }
-    ) { content() }
+            attrs?.invoke(this)
+        },
+        content = content
+    )
 }


### PR DESCRIPTION
- Creates a "real" link (with an actual href), which allows to ctrl-click / cmd-click or right click and open the link in a new tab / window. The `onClick` callback uses `preventDefault` to prevent reloading the page.
- Moves `attrs?.invoke(this)` at the bottom (to allow for overrides and conform to standard).
- `content` is nullable as it must be possible to create a NavLink without content (entirely described by its style).