### PR TITLE
fix: path contains more than 1 '?' delimiter with using parameters

### DIFF
--- a/src/commonMain/kotlin/app/softwork/routingcompose/Parameters.kt
+++ b/src/commonMain/kotlin/app/softwork/routingcompose/Parameters.kt
@@ -57,7 +57,7 @@ public class Parameters private constructor(public val raw: String, public val m
                 values.mapNotNull {
                     if (it.isEmpty()) null else "$key=$it"
                 }
-            }.joinToString(separator = "&", prefix = "?") {
+            }.joinToString(separator = "&") {
                 it.percentDecode()
             }
             return Parameters(raw, parameters)


### PR DESCRIPTION
When this line works with Path.kt#L48, they will create a URL with double `?` and then causes an exception: `path contains more than 1 '?' delimiter:`.

Test code:
```kotlin
NavLink(
            router.currentPath
                .copy(parameters = Parameters.from((router.currentPath.parameters?.map?.toMutableMap() ?: mutableMapOf()))
                .toString()
        ) {
            Text("test")
        }
```