### PR TITLE
Make HashRouter and BrowserRouter internal classes

### DIFF
--- a/integrationTest/browserRouterTest/src/main/kotlin/main.kt
+++ b/integrationTest/browserRouterTest/src/main/kotlin/main.kt
@@ -3,6 +3,8 @@ import org.jetbrains.compose.web.*
 
 fun main() {
     renderComposableInBody {
-        Demo(BrowserRouter(), "BrowserRouter")
+        BrowserRouter("/") {
+            Demo("BrowserRouter")
+        }
     }
 }

--- a/integrationTest/hashRouterTest/src/main/kotlin/main.kt
+++ b/integrationTest/hashRouterTest/src/main/kotlin/main.kt
@@ -3,6 +3,8 @@ import org.jetbrains.compose.web.*
 
 fun main() {
     renderComposableInBody {
-        Demo(HashRouter(), "HashRouter")
+        HashRouter("/") {
+            Demo("HashRouter")
+        }
     }
 }

--- a/integrationTest/src/jsMain/kotlin/demo.kt
+++ b/integrationTest/src/jsMain/kotlin/demo.kt
@@ -9,16 +9,15 @@ import org.jetbrains.compose.web.css.Color.white
 import org.jetbrains.compose.web.dom.*
 import kotlin.time.Duration.Companion.seconds
 
+@Routing
 @Composable
-fun Demo(router: Router, name: String) {
+fun RouteBuilder.Demo(name: String) {
     Style(DarkMode)
 
     P {
         Text("$name implementation")
     }
-    router.route("/") {
-        Routing()
-    }
+    Routing()
 }
 
 object DarkMode : StyleSheet() {
@@ -40,6 +39,7 @@ object DarkMode : StyleSheet() {
 
 private const val Players = 5
 
+@Routing
 @Composable
 fun RouteBuilder.Users() {
     P {
@@ -90,13 +90,17 @@ fun RouteBuilder.Routing() {
     Clock()
     NavLink(to = "/", attrs = { selected ->
         if (selected) {
-            classes("active")
+            style {
+                color(Color.red)
+            }
         }
     }) { Text("Main") }
     Br()
     NavLink(to = "/users", attrs = { selected ->
         if (selected) {
-            classes("active")
+            style {
+                color(Color.red)
+            }
         }
     }) { Text("Users") }
 

--- a/src/jsMain/kotlin/app/softwork/routingcompose/BrowserRouter.kt
+++ b/src/jsMain/kotlin/app/softwork/routingcompose/BrowserRouter.kt
@@ -29,7 +29,7 @@ public fun BrowserRouter(
     BrowserRouter().route(initPath, routeBuilder)
 }
 
-public class BrowserRouter : Router {
+internal class BrowserRouter : Router {
     override val currentPath: Path
         get() = Path.from(currentLocation.value)
 

--- a/src/jsMain/kotlin/app/softwork/routingcompose/HashRouter.kt
+++ b/src/jsMain/kotlin/app/softwork/routingcompose/HashRouter.kt
@@ -17,7 +17,7 @@ public fun HashRouter(
     HashRouter().route(initPath, routeBuilder)
 }
 
-public class HashRouter : Router {
+internal class HashRouter : Router {
     override val currentPath: Path
         get() = Path.from(currentHash.value)
 


### PR DESCRIPTION
Use the composable functions and CompositionLocalProvider (`Router.current`) instead to prevent using the wrong router in sub routes with relative paths.

Classes to support configuration at some point